### PR TITLE
darklua.process files in place

### DIFF
--- a/src/lib.luau
+++ b/src/lib.luau
@@ -239,6 +239,31 @@ function multitarget.build(
 		local targetDir = pathfs.Directory.new(outputDir.path:join(target))
 		targetDir:writeDir() -- assure it exists (may not exist later if the user uses "includes" incorrectly, which would throw an undescriptive error later when trying to access this directory)
 
+		local globIgnore = {}
+		if buildFiles then
+			for _, buildFile in buildFiles do
+				local destination = targetDir.path:join(buildFile)
+				local parent = destination:parent()
+				if parent then
+					fs.writeDir(parent)
+				end
+
+				fs.copy(buildFile, destination, true)
+
+				local wdFilePath = pathfs.canonicalize(buildFile):stripPrefix(workingDirPath)
+				if not wdFilePath then
+					continue
+				end
+
+				local wdFilePathStr = wdFilePath:toString()
+				if fs.isFile(buildFile) then
+					table.insert(globIgnore, wdFilePathStr)
+				elseif fs.isDir(buildFile) then
+					table.insert(globIgnore, wdFilePathStr .. "/**")
+				end
+			end
+		end
+
 		-- selene: allow(shadowing)
 		local newPesdeToml = tableHelper.copy(pesdeToml, true)
 		if newPesdeToml.includes then
@@ -246,6 +271,7 @@ function multitarget.build(
 				for _, path in
 					glob(include, {
 						cwd = workingDirPath,
+						ignore = globIgnore, -- We don't have to process these as everything in this list already got copied over in the step above
 					})
 				do
 					local dest = targetDir.path:join(

--- a/src/lib.luau
+++ b/src/lib.luau
@@ -398,8 +398,8 @@ function multitarget.build(
 			end
 
 			for _, buildFile in buildFiles do
-				local darkluaOutputPath = targetDir.path:join(buildFile):toString()
-				darklua.process(buildFile, darkluaOutputPath, {
+				local targetBuildFile = targetDir.path:join(buildFile):toString()
+				darklua.process(targetBuildFile, targetBuildFile, {
 					rules = rules,
 				})
 			end


### PR DESCRIPTION
This will change the current behaviour of processing the actual source files into the build output, and now processes the already existing copies of the source files instead with themselves as the output.

This avoids issues where darklua doesn't know what .luaurc file to pull configs from. Before it would pull them from the user's own .luaurc, but this pr will fix that and it will now use the .luaurc files generated by pesde-multitarget.